### PR TITLE
Updated to display uncollected icon for gray and white items

### DIFF
--- a/Bagnon_ItemInfo/modules/uncollected.lua
+++ b/Bagnon_ItemInfo/modules/uncollected.lua
@@ -50,7 +50,7 @@ Private.AddUpdater(Module, function(self)
 
 		local quality, id = self.info.quality, self.info.id
 
-		if (quality and quality > 1 and not PlayerHasTransmog(id --[[, itemAppearanceModID ]])) then
+		if (quality >= 0 and not PlayerHasTransmog(id --[[, itemAppearanceModID ]])) then
 
 			if (not tooltip.owner or not tooltip.bag or not tooltip.slot) then
 				tooltip.owner, tooltip.bag,tooltip.slot = self, self:GetBag(), self:GetID()


### PR DESCRIPTION
Simple commit to enable uncollected appearance icon to display on gray and white items.