### PR TITLE
Updated slash command

### DIFF
--- a/Bagnon_ItemInfo/defaults.lua
+++ b/Bagnon_ItemInfo/defaults.lua
@@ -36,45 +36,110 @@ BagnonItemInfo_DB = {
 	enableRarityColoring = true
 }
 
+local function PrintHelp()
+	print("Bagnon ItemInfo")
+	print("Adjust configurations with the following commands:")
+	print("/bif enable itemlevel - Enable the itemlevel display.")
+	print("/bif disable itemlevel - Disable the itemlevel display.")
+	print("/bif enable boe - Enable the BoE/BoU display.")
+	print("/bif disable boe - Disable the BoE/BoU display.")
+	print("/bif enable garbage - Enable the garbage desaturation.")
+	print("/bif disable garbage - Disable the garbage desaturation.")
+	print("/bif enable uncollected - Enable the uncollected appearance eye.")
+	print("/bif disable uncollected - Disable the uncollected appearance eye.")
+	print("/bif enable color - Enable rarity coloring of text.")
+	print("/bif disable color - Disable rarity coloring of text.")
+end
+
+--
+-- Sets configuration for the provided configuration key
+--
+local function SetConfiguration(configName, configKey, effect)
+	local db = BagnonItemInfo_DB
+
+	if ( effect == "toggle" ) then
+		local initialValue = db[configKey]
+		if ( initialValue ) then
+			db[configKey] = false
+		else
+			db[configKey] = true
+		end
+	else
+		db[configKey] = effect
+	end
+
+	if ( db[configKey] ) then
+		print("Bagnon ItemInfo:", configName, "enabled")
+	else
+		print("Bagnon ItemInfo:", configName, "disabled")
+	end
+end
+
+local function InvalidCommand(command)
+	if ( command  and command ~= "" ) then
+		print(command, "is not a valid command.")
+	end
+	PrintHelp()
+	return
+end
+
 SLASH_BAGNON_ITEMLEVEL1 = "/bif"
 SlashCmdList["BAGNON_ITEMLEVEL"] = function(msg)
 	if (not msg) then
-		return
+		return InvalidCommand(msg)
 	end
 
 	msg = string.gsub(msg, "^%s+", "")
 	msg = string.gsub(msg, "%s+$", "")
 	msg = string.gsub(msg, "%s+", " ")
 
-	local action, element = string.split(" ", msg)
-	local db = BagnonItemInfo_DB
+	local arg1, arg2 = string.split(" ", msg)
 
-	if (action == "enable") then
-		if (element == "itemlevel" or element == "ilvl") then
-			db.enableItemLevel = true
-		elseif (element == "boe" or element == "bind") then
-			db.enableItemBind = true
-		elseif (element == "junk" or element == "trash" or element == "garbage") then
-			db.enableGarbage = true
-		elseif (element == "eye" or element == "transmog" or element == "uncollected") then
-			db.enableUncollected = true
-		elseif (element == "color") then
-			db.enableRarityColoring = true
-		end
+	local action = "toggle"
+	local element = ""
 
-	elseif (action == "disable") then
-		if (element == "itemlevel" or element == "ilvl") then
-			db.enableItemLevel = false
-		elseif (element == "boe" or element == "bind") then
-			db.enableItemBind = false
-		elseif (element == "junk" or element == "trash" or element == "garbage") then
-			db.enableGarbage = false
-		elseif (element == "eye" or element == "transmog" or element == "uncollected") then
-			db.enableUncollected = false
-		elseif (element == "color") then
-			db.enableRarityColoring = false
-		end
+	if ( arg1 == "enable" or arg1 == "disable" ) then
+		action = arg1
+		element = arg2
+	elseif ( arg2 == "enable" or arg2 == "disable" ) then
+		action = arg2
+		element = arg1
+	elseif ( arg1 ~= "" and not arg2 ) then
+		element = arg1
+	else
+		return InvalidCommand(msg)
 	end
+
+	local effect = "toggle"
+	if ( action == "enable" ) then
+		effect = true
+	elseif ( action == "disable" ) then
+		effect = false
+	end
+
+	local configKey
+	local configName
+
+	if (element == "itemlevel" or element == "ilvl") then
+		configKey = "enableItemLevel"
+		configName = "Item Level"
+	elseif (element == "boe" or element == "bind") then
+		configKey = "enableItemBind"
+		configName = "BoE Display"
+	elseif (element == "junk" or element == "trash" or element == "garbage") then
+		configKey = "enableGarbage"
+		configName = "Garbage Desaturator"
+	elseif (element == "eye" or element == "transmog" or element == "uncollected") then
+		configKey = "enableUncollected"
+		configName = "Uncollected Icon"
+	elseif (element == "color") then
+		configKey = "enableRarityColoring"
+		configName = "Rarity Text Color"
+	else
+		return InvalidCommand(msg)
+	end
+
+	SetConfiguration(configName, configKey, effect)
 
 	if (Private.Forceupdate) then
 		Private.Forceupdate()


### PR DESCRIPTION
Added new feature support to extend usability of slash commands with the following purpose:
1. To output messages to allow a user to know the changes going on within the Addon. This includes supporting "help" messaging when a command is invalid.
2. Supporting additional methods to adjust configuration, including toggling between enable/disable and putting the "element" first. For example, the current live version of this addon would only support `/bif enable color` or `/bif disable color`. With this change, a user could use the two commands above. However, a user could also use `/bif color enable`, `/bif color disable`, or even `/bif color` to toggle between the enable/disable for that configuration item.

# Changelog
Refactored slash command function to support the following items:
    - Displaying help text when no command or invalid command is provided
    - Supporting enable/disable as first or second argument
    - Supporting toggling of a configuration item
    - Outputting messages for updates to any configuration change